### PR TITLE
Seeding the initial state of the environment

### DIFF
--- a/gym_cap/gym_cap/envs/cap_env.py
+++ b/gym_cap/gym_cap/envs/cap_env.py
@@ -49,9 +49,9 @@ class CapEnv(gym.Env):
         """
 
         if map_size is None:
-            self._env, self.team_home = CreateMap.gen_map('map', dim=self.map_size[0], rand_zones=STOCH_ZONES)
+            self._env, self.team_home = CreateMap.gen_map('map', dim=self.map_size[0], rand_zones=STOCH_ZONES, np_random=self.np_random)
         else:
-            self._env, self.team_home = CreateMap.gen_map('map', map_size, rand_zones=STOCH_ZONES)
+            self._env, self.team_home = CreateMap.gen_map('map', map_size, rand_zones=STOCH_ZONES, np_random=self.np_random)
 
         self.map_size = (len(self._env), len(self._env[0]))
 

--- a/gym_cap/gym_cap/envs/cap_env.py
+++ b/gym_cap/gym_cap/envs/cap_env.py
@@ -294,6 +294,7 @@ class CapEnv(gym.Env):
             CapEnv object
         """
         self.np_random, seed = seeding.np_random(seed)
+        np.random.seed(seed)
         return [seed]
 
     def step(self, entities_action=None, cur_suggestions=None):

--- a/gym_cap/gym_cap/envs/cap_env.py
+++ b/gym_cap/gym_cap/envs/cap_env.py
@@ -279,7 +279,7 @@ class CapEnv(gym.Env):
                         n_friends += 1
                     elif entity.team == TEAM2_BACKGROUND and self._env[locx][locy] == TEAM2_UGV:
                         n_friends += 1
-        if flag and np.random.rand() > n_friends/(n_friends + n_enemies):
+        if flag and self.np_random.rand() > n_friends/(n_friends + n_enemies):
 
             entity.isAlive = False
             self._env[loc] = DEAD
@@ -294,7 +294,6 @@ class CapEnv(gym.Env):
             CapEnv object
         """
         self.np_random, seed = seeding.np_random(seed)
-        np.random.seed(seed)
         return [seed]
 
     def step(self, entities_action=None, cur_suggestions=None):

--- a/gym_cap/gym_cap/envs/create_map.py
+++ b/gym_cap/gym_cap/envs/create_map.py
@@ -7,7 +7,7 @@ class CreateMap:
     and number of agents for each team"""
 
     @staticmethod
-    def gen_map(name, dim=20, in_seed=None, rand_zones=False,
+    def gen_map(name, dim=20, in_seed=None, rand_zones=False, np_random=None
                 map_obj=[NUM_BLUE, NUM_UAV, NUM_RED, NUM_UAV, NUM_GRAY]):
         """
         Method
@@ -32,6 +32,8 @@ class CreateMap:
         """
 
         # init the seed and set new_map to zeros
+        if np_random == None:
+            np_random = np.random
         if not in_seed == None:
             np.random.seed(in_seed)
         new_map = np.zeros([dim, dim], dtype=int)
@@ -39,8 +41,8 @@ class CreateMap:
         # zones init
         new_map[:,:] = TEAM2_BACKGROUND
         if rand_zones:
-            sx, sy = np.random.randint(dim//2, 4*dim//5, [2])
-            lx, ly = np.random.randint(0, dim - max(sx,sy)-1, [2])
+            sx, sy = np_random.randint(dim//2, 4*dim//5, [2])
+            lx, ly = np_random.randint(0, dim - max(sx,sy)-1, [2])
             new_map[lx:lx+sx, ly:ly+sy] = TEAM1_BACKGROUND
         else:
             new_map[:,0:dim//2] = TEAM1_BACKGROUND
@@ -48,8 +50,8 @@ class CreateMap:
         # obstacles init
         num_obst = int(np.sqrt(dim))
         for i in range(num_obst):
-            lx, ly = np.random.randint(0, dim, [2])
-            sx, sy = np.random.randint(0, dim//5, [2]) + 1
+            lx, ly = np_random.randint(0, dim, [2])
+            sx, sy = np_random.randint(0, dim//5, [2]) + 1
             new_map[lx-sx:lx+sx, ly-sy:ly+sy] = OBSTACLE
 
         # define location of flags

--- a/gym_cap/gym_cap/envs/create_map.py
+++ b/gym_cap/gym_cap/envs/create_map.py
@@ -7,7 +7,7 @@ class CreateMap:
     and number of agents for each team"""
 
     @staticmethod
-    def gen_map(name, dim=20, in_seed=None, rand_zones=False, np_random=None
+    def gen_map(name, dim=20, in_seed=None, rand_zones=False, np_random=None,
                 map_obj=[NUM_BLUE, NUM_UAV, NUM_RED, NUM_UAV, NUM_GRAY]):
         """
         Method


### PR DESCRIPTION
# Issue
For debugging purpose, it would be nice to be able to fix the environment. The env.seed() method is the most intuitive method to use, but it is not functioning correctly.

# Solution
I think the current issue is that the env.seed() method only fix the seed of the random generator class within the gym environment, and it does not fix the numpy seed. I simply added a line that fix the numpy seed, and it would be a temporary solution.

``` py
...
self.np_random, seed = seeding.np_random(seed)
np.random.seed(seed)
return [seed]
```

# For Future
The problem with this code is that all the numpy random generator would be fixed. If we want to use numpy random somewhere else with fixed environment, it would cause some problems. Ideally, all the random number generation in initializing environment needs to use the separate random generator with its own seed.